### PR TITLE
Add example and fix package installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Or copy files from releases.
 #### Use
 Include the CSS and JavaScript files located in ```\dist``` directory.
 ```html
-<script src=".../L.Icon.Pulse.js" />
-<link rel="stylesheet" href=".../L.Icon.Pulse.css" />
+<script src="../L.Icon.Pulse.js" />
+<link rel="stylesheet" href="../L.Icon.Pulse.css" />
 ```
 
 ### Usage

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title>Leaflet icon-pulse example</title>
+
+		<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css" />
+		<script src="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js"></script>
+		<style>
+			#map { height: 480px; }
+		</style>
+
+		<link rel="stylesheet" href="../dist/L.Icon.Pulse.css" />
+		<script src="../dist/L.Icon.Pulse.js"></script>
+	</head>
+	<body>
+		<div id="map"></div>
+		<script src="index.js"></script>
+	</body>
+</html>

--- a/example/index.js
+++ b/example/index.js
@@ -1,0 +1,15 @@
+(function() {
+    var map = new L.Map('map', {
+            center: new L.LatLng(52.520, 13.385),
+            zoom: 5
+        }),
+        layer = new L.tileLayer('http://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png', {
+            minZoom: 5,
+            maxZoom: 18
+        });
+
+    map.addLayer(layer);
+
+    var pulsingIcon = L.icon.pulse({iconSize:[20,20],color:'red'});
+    var marker = L.marker([52.9167,13.9333],{icon: pulsingIcon}).addTo(map);
+})();

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "leaflet"
   ],
   "scripts": {
-    "postinstall": "node_modules/gobble-cli/lib/index.js build -f dist",
-    "watch": "node_modules/gobble-cli/lib/index.js watch -f dist"
+    "postinstall": "gobble build -f dist",
+    "watch": "gobble watch -f dist"
   }
 }


### PR DESCRIPTION
I've just added an example and fixed the `package.json` in order to be able to install the module at least using `npm install git+https://github.com/mapshakers/leaflet-icon-pulse`.

The complete path `node_modules/gobble-cli/lib/index.js` isn't necessary, since npm exports automatically the folder `node_modules/.bin` to the `PATH`, making `gobble` available.

I would be happy to see the package published on **npm**, as already pointed out in #2
