### PR TITLE
fix the CSS issue when animation is stopped

### DIFF
--- a/src/L.Icon.Pulse.js
+++ b/src/L.Icon.Pulse.js
@@ -29,6 +29,7 @@
 
             if (!this.options.animate){
                 after.push('animation: none');
+                after.push('box-shadow:none');
             }
 
             var css = [


### PR DESCRIPTION
Hi,
 This pull request fixes the issue #7 which is "Animation stop for the pulsating icon not correct". The issue can be solved by adding a CSS attribute `box-shadow: none `..