### PR TITLE
support for fillColor

### DIFF
--- a/src/L.Icon.Pulse.js
+++ b/src/L.Icon.Pulse.js
@@ -5,6 +5,7 @@
         options: {
             className: '',
             iconSize: [12,12],
+            fillColor: 'red',
             color: 'red',
             animate: true,
             heartbeat: 1,
@@ -17,7 +18,7 @@
             
             var uniqueClassName = 'lpi-'+ new Date().getTime()+'-'+Math.round(Math.random()*100000);
 
-            var before = ['background-color: '+this.options.color];
+            var before = ['background-color: '+this.options.fillColor];
             var after = [
 
                 'box-shadow: 0 0 6px 2px '+this.options.color,


### PR DESCRIPTION
hi!

I think for more cases could be useful setting the fillColor to integrate it maps having just styled clicrcleMarkers.

for example in my case here:
[keplerjs.io](http://keplerjs.io/)

I want show only the effect pulse without fillColor
thanks for your patience
Stefano
